### PR TITLE
Add basic test suite for sports API and betting combinations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==21.0
 requests==2.31.0
 python-dotenv==1.0.0
 aiohttp==3.9.1
+pytest==8.0.2

--- a/tests/test_betting_analyzer.py
+++ b/tests/test_betting_analyzer.py
@@ -1,0 +1,20 @@
+from betting_analyzer import BettingAnalyzer
+
+
+def test_generate_specific_combination():
+    analyzer = BettingAnalyzer()
+    analyses = [
+        {"match": "A vs B", "recommendation": "A wins (cote: 1.5)", "confidence": 80},
+        {"match": "C vs D", "recommendation": "C wins (cote: 1.8)", "confidence": 75},
+        {"match": "E vs F", "recommendation": "E wins (cote: 2.0)", "confidence": 70},
+        {"match": "G vs H", "recommendation": "G wins (cote: 1.9)", "confidence": 65},
+        {"match": "I vs J", "recommendation": "I wins (cote: 1.7)", "confidence": 50},
+    ]
+
+    combo = analyzer.generate_specific_combination(analyses, "MOYEN")
+    assert combo is not None
+    assert combo["type"] == "Combiné MOYEN ⚖️"
+    assert len(combo["matches"]) == 4
+    assert {"type", "matches", "total_odds", "avg_confidence", "potential_return"}.issubset(combo)
+    for m in combo["matches"]:
+        assert {"match", "bet", "confidence"}.issubset(m)

--- a/tests/test_sports_api.py
+++ b/tests/test_sports_api.py
@@ -1,0 +1,26 @@
+import pytest
+from sports_api import SportsAPI
+
+
+def test_generate_demo_matches_structure():
+    api = SportsAPI(api_key="demo", demo_mode=True)
+    matches = api._generate_demo_matches("soccer_epl", "Premier League")
+
+    assert 3 <= len(matches) <= 6
+    required_match_keys = {"id", "sport_key", "sport_title", "commence_time", "home_team", "away_team", "bookmakers"}
+
+    for match in matches:
+        # basic fields
+        assert required_match_keys.issubset(match)
+        assert match["sport_key"] == "soccer_epl"
+        assert match["sport_title"] == "Premier League"
+        # bookmakers structure
+        assert isinstance(match["bookmakers"], list) and match["bookmakers"]
+        bookmaker = match["bookmakers"][0]
+        assert {"key", "title", "markets"}.issubset(bookmaker)
+        assert isinstance(bookmaker["markets"], list) and bookmaker["markets"]
+        market = bookmaker["markets"][0]
+        assert {"key", "outcomes"}.issubset(market)
+        assert isinstance(market["outcomes"], list) and len(market["outcomes"]) >= 2
+        outcome = market["outcomes"][0]
+        assert {"name", "price"}.issubset(outcome)


### PR DESCRIPTION
## Summary
- add unit test for demo match generation
- add unit test for specific combination builder
- configure pytest and requirements

## Testing
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689beb11da7883319de43e1bf82af615