### PR TITLE
Load odds and cache settings from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ TELEGRAM_BOT_TOKEN=votre_token_telegram
 THE_ODDS_API_KEY=votre_cle_api_odds  # Optionnel pour le mode démo
 ```
 
+### Ajuster les paramètres d'analyse
+
+Modifiez les valeurs dans `config.py` pour personnaliser le comportement du bot :
+
+- `MIN_ODDS` et `MAX_ODDS` : limites des cotes étudiées.
+- `CACHE_TIMEOUT` : durée en secondes pendant laquelle les résultats API sont mis en cache.
+
+Ces paramètres permettent d'affiner la stratégie selon vos préférences.
+
 ## Démarrage
 
 ### Mode normal (avec API réelle) :

--- a/betting_analyzer.py
+++ b/betting_analyzer.py
@@ -7,13 +7,14 @@ import random
 from typing import Dict, List, Tuple, Optional
 from datetime import datetime
 import logging
+import config
 
 logger = logging.getLogger(__name__)
 
 class BettingAnalyzer:
     """Analyseur de paris sportifs et générateur de combinés"""
     
-    def __init__(self, min_odds: float = 1.5, max_odds: float = 5.0):
+    def __init__(self, min_odds: float = config.MIN_ODDS, max_odds: float = config.MAX_ODDS):
         """
         Initialise l'analyseur
         
@@ -148,7 +149,7 @@ class BettingAnalyzer:
         
         # Ajustement selon les cotes
         recommended_odds = analysis['recommended_odds']
-        if recommended_odds < 1.5:
+        if recommended_odds < config.MIN_ODDS:
             base_confidence += 20  # Bonus pour les favoris
         elif recommended_odds > 4.0:
             base_confidence -= 15  # Malus pour les outsiders
@@ -500,6 +501,6 @@ class BettingAnalyzer:
         return probs
 
 # Fonction utilitaire pour créer un analyseur
-def create_betting_analyzer(min_odds: float = 1.5, max_odds: float = 5.0) -> BettingAnalyzer:
+def create_betting_analyzer(min_odds: float = config.MIN_ODDS, max_odds: float = config.MAX_ODDS) -> BettingAnalyzer:
     """Crée une instance de BettingAnalyzer"""
     return BettingAnalyzer(min_odds, max_odds)

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from dotenv import load_dotenv
 
 from sports_api import create_sports_api
 from betting_analyzer import create_betting_analyzer
+import config
 
 # Configuration du logging
 logging.basicConfig(
@@ -51,11 +52,11 @@ class BetIQ25Bot:
             self.demo_mode = True
         
         self.sports_api = create_sports_api(self.odds_api_key or "demo", self.demo_mode)
-        self.betting_analyzer = create_betting_analyzer()
+        self.betting_analyzer = create_betting_analyzer(config.MIN_ODDS, config.MAX_ODDS)
         
         # Cache pour éviter trop de requêtes API
         self.cache = {}
-        self.cache_timeout = 300  # 5 minutes
+        self.cache_timeout = config.CACHE_TIMEOUT
         
         # Système de tracking des utilisateurs
         self.users_file = Path("known_users.json")


### PR DESCRIPTION
## Summary
- Import `config` and use its `MIN_ODDS` and `MAX_ODDS` when creating the betting analyzer
- Replace hardcoded cache timeout with `config.CACHE_TIMEOUT`
- Document how to adjust odds and cache settings in `config.py`

## Testing
- `python -m py_compile main.py betting_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_b_689beb0cbbf4833180f5a8d83bcf1fb7